### PR TITLE
Fix prediction typo in OS detection payloads

### DIFF
--- a/payloads/extensions/os_detect.txt
+++ b/payloads/extensions/os_detect.txt
@@ -103,7 +103,7 @@ EXTENSION OS_DETECTION
                 ENTER
                 STRING no led response
                 ENTER
-                STRING prediciton: MacOS
+                STRING prediction: MacOS
             END_IF_DEFINED
             $_OS = MACOS
         END_IF
@@ -140,7 +140,7 @@ EXTENSION OS_DETECTION
                             ENTER
                             STRING no numlock led
                             ENTER
-                            STRING prediciton: ChromeOS
+                            STRING prediction: ChromeOS
                         END_IF_DEFINED
                         $_OS = CHROMEOS
                     ELSE
@@ -161,7 +161,7 @@ EXTENSION OS_DETECTION
                                 ENTER
                                 STRING scrolllock led on
                                 ENTER
-                                STRING prediciton: Android
+                                STRING prediction: Android
                             END_IF_DEFINED
                             $_OS = ANDROID
                         ELSE

--- a/payloads/library/exfiltration/WifiCredSidechannelExfil/payload.txt
+++ b/payloads/library/exfiltration/WifiCredSidechannelExfil/payload.txt
@@ -95,7 +95,7 @@ EXTENSION OS_DETECTION
                 ENTER
                 STRING no led response
                 ENTER
-                STRING prediciton: MacOS
+                STRING prediction: MacOS
             END_IF
             $_OS = MACOS
         END_IF
@@ -132,7 +132,7 @@ EXTENSION OS_DETECTION
                             ENTER
                             STRING no numlock led
                             ENTER
-                            STRING prediciton: ChromeOS
+                            STRING prediction: ChromeOS
                         END_IF
                         $_OS = CHROMEOS
                     ELSE
@@ -153,7 +153,7 @@ EXTENSION OS_DETECTION
                                 ENTER
                                 STRING scrolllock led on
                                 ENTER
-                                STRING prediciton: Android
+                                STRING prediction: Android
                             END_IF
                             $_OS = ANDROID
                         ELSE

--- a/payloads/library/exfiltration/WifiProfileExtractor/payload.txt
+++ b/payloads/library/exfiltration/WifiProfileExtractor/payload.txt
@@ -94,7 +94,7 @@ EXTENSION OS_DETECTION
                 ENTER
                 STRING no led response
                 ENTER
-                STRING prediciton: MacOS
+                STRING prediction: MacOS
             END_IF
             $_OS = MACOS
         END_IF
@@ -131,7 +131,7 @@ EXTENSION OS_DETECTION
                             ENTER
                             STRING no numlock led
                             ENTER
-                            STRING prediciton: ChromeOS
+                            STRING prediction: ChromeOS
                         END_IF
                         $_OS = CHROMEOS
                     ELSE
@@ -152,7 +152,7 @@ EXTENSION OS_DETECTION
                                 ENTER
                                 STRING scrolllock led on
                                 ENTER
-                                STRING prediciton: Android
+                                STRING prediction: Android
                             END_IF
                             $_OS = ANDROID
                         ELSE

--- a/payloads/library/general/Piano_Player/examples/game_of_thrones_payload.txt
+++ b/payloads/library/general/Piano_Player/examples/game_of_thrones_payload.txt
@@ -90,7 +90,7 @@ EXTENSION OS_DETECTION
                 ENTER
                 STRING no led response
                 ENTER
-                STRING prediciton: MacOS
+                STRING prediction: MacOS
             END_IF
             $_OS = MACOS
         END_IF
@@ -127,7 +127,7 @@ EXTENSION OS_DETECTION
                             ENTER
                             STRING no numlock led
                             ENTER
-                            STRING prediciton: ChromeOS
+                            STRING prediction: ChromeOS
                         END_IF
                         $_OS = CHROMEOS
                     ELSE
@@ -148,7 +148,7 @@ EXTENSION OS_DETECTION
                                 ENTER
                                 STRING scrolllock led on
                                 ENTER
-                                STRING prediciton: Android
+                                STRING prediction: Android
                             END_IF
                             $_OS = ANDROID
                         ELSE

--- a/payloads/library/general/Piano_Player/examples/super_mario_payload.txt
+++ b/payloads/library/general/Piano_Player/examples/super_mario_payload.txt
@@ -90,7 +90,7 @@ EXTENSION OS_DETECTION
                 ENTER
                 STRING no led response
                 ENTER
-                STRING prediciton: MacOS
+                STRING prediction: MacOS
             END_IF
             $_OS = MACOS
         END_IF
@@ -127,7 +127,7 @@ EXTENSION OS_DETECTION
                             ENTER
                             STRING no numlock led
                             ENTER
-                            STRING prediciton: ChromeOS
+                            STRING prediction: ChromeOS
                         END_IF
                         $_OS = CHROMEOS
                     ELSE
@@ -148,7 +148,7 @@ EXTENSION OS_DETECTION
                                 ENTER
                                 STRING scrolllock led on
                                 ENTER
-                                STRING prediciton: Android
+                                STRING prediction: Android
                             END_IF
                             $_OS = ANDROID
                         ELSE

--- a/payloads/library/prank/Multi_HID_HeyGotAnyGrapes/payload.txt
+++ b/payloads/library/prank/Multi_HID_HeyGotAnyGrapes/payload.txt
@@ -93,7 +93,7 @@ EXTENSION OS_DETECTION
                 ENTER
                 STRING no led response
                 ENTER
-                STRING prediciton: MacOS
+                STRING prediction: MacOS
             END_IF
             $_OS = MACOS
         END_IF
@@ -130,7 +130,7 @@ EXTENSION OS_DETECTION
                             ENTER
                             STRING no numlock led
                             ENTER
-                            STRING prediciton: ChromeOS
+                            STRING prediction: ChromeOS
                         END_IF
                         $_OS = CHROMEOS
                     ELSE
@@ -151,7 +151,7 @@ EXTENSION OS_DETECTION
                                 ENTER
                                 STRING scrolllock led on
                                 ENTER
-                                STRING prediciton: Android
+                                STRING prediction: Android
                             END_IF
                             $_OS = ANDROID
                         ELSE


### PR DESCRIPTION
## Summary
- fix spelling of "prediction" in OS detection extension
- apply the same correction to example payloads using the extension

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68999187def483209a7576f1dc70d73d